### PR TITLE
Filter with missing levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Imports:
     shiny (>= 1.3.1),
     shinycssloaders,
     shinydashboard,
-    shinydashboardPlus,
     shinyjs,
     tidyr,
     V8,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FacileShine
 Type: Package
 Title: Shiny primitives to interact with FacileData and FacileViz objects.
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("Steve", "Lianoglou", , "lianoglou@dnli.com", c("aut", "cre"),
       comment = c(ORCID = "0000-0002-0924-1754")),

--- a/R/sampleFilterList-module.R
+++ b/R/sampleFilterList-module.R
@@ -195,7 +195,7 @@ sampleFilterList <- function(input, output, session, rfds,
   observe({
     filters. <- filters()
     flen <- length(filters.)
-    if (flen == 0) {
+    if (flen == 0L) {
       enabled <- TRUE
     } else {
       f <- filters.[[flen]]

--- a/man/categoricalSampleCovariateLevels.Rd
+++ b/man/categoricalSampleCovariateLevels.Rd
@@ -10,6 +10,7 @@ categoricalSampleCovariateLevels(
   session,
   rfds,
   covariate,
+  missing_sentinel = NULL,
   ...,
   .exclude = NULL,
   .reactive = TRUE,
@@ -17,6 +18,11 @@ categoricalSampleCovariateLevels(
 )
 }
 \arguments{
+\item{missing_sentinel}{This is a reactive (string). When it's NULL, no
+missing sentinel is added. The parent covariate selector can pass in a
+value here to show to indicate a level that's not included in the
+covariate's level.}
+
 \item{covaraite}{the \code{categoricalSampleCovariateSelect} module.}
 }
 \description{

--- a/tests/shiny-modules/shinytest-filteredReactiveFacileDataStore.R
+++ b/tests/shiny-modules/shinytest-filteredReactiveFacileDataStore.R
@@ -10,6 +10,7 @@ efds <- exampleFacileDataSet()
 # With filter
 single <- shinyApp(
   ui = fluidPage(
+    shinyjs::useShinyjs(),
     filteredReactiveFacileDataStoreUI("rfds", debug = TRUE)),
   server = function(input, output) {
     path <- reactive(efds$parent.dir)

--- a/tests/shiny-modules/shinytest-sampleFilter.R
+++ b/tests/shiny-modules/shinytest-sampleFilter.R
@@ -10,8 +10,8 @@ efds <- exampleFacileDataSet()
 
 # With filter
 single <- shinyApp(
-  shinyjs::useShinyjs(),
   ui = fluidPage(
+    shinyjs::useShinyjs(),
     reactiveFacileDataStoreUI("rfds"),
     tags$h3("Sample filter with no preset universe"),
     sampleFilterUI("sf", debug = debug),


### PR DESCRIPTION
The sampleFilter module now can include samples that have no annotation for the current covariate being filtered against.

This helps us to better support the "ragged sample annotation" reality of the data as more and more datasets are harmonized into a larger one for über exploration.
