### PR TITLE
Fixes to in_sync in assaySelect and assayFeatureSelect modules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FacileShine
 Type: Package
 Title: Shiny primitives to interact with FacileData and FacileViz objects.
-Version: 0.98.14
+Version: 0.98.15
 Authors@R: c(
     person("Steve", "Lianoglou", , "slianoglou@gmail.com", c("aut", "cre"),
       comment = c(ORCID = "0000-0002-0924-1754")))

--- a/R/fboxPlot-modules.R
+++ b/R/fboxPlot-modules.R
@@ -26,8 +26,9 @@ fboxPlotServer <- function(id, rfds, ...,
     # "Individual" checkbox is only active when multiple genes are entered
     # in the y-axis selector
     observe({
-      nvals <- nrow(yaxis$selected())
-      shinyjs::toggleState("individual", condition = nvals > 1)
+      ys <- req(yaxis$selected())
+      # browser()
+      shinyjs::toggleState("individual", condition = nrow(ys) > 1)
     })
     
     # Due to the limitations of the curent boxplot implementation, if the user
@@ -42,10 +43,14 @@ fboxPlotServer <- function(id, rfds, ...,
     rdat.core <- reactive({
       indiv. <- input$individual
       yvals. <- yaxis$selected()
-      req(!unselected(yvals.), yaxis$in_sync())
+      ftrace("{reset}{bold}{red}rdat.core: testing if yaxis is ready ...")
+      # req(!unselected(yvals.), yaxis$in_sync())
+      req(!unselected(yvals.))
       
       xaxis. <- xaxis$selected()
-      req(!unselected(xaxis.), xaxis$in_sync())
+      ftrace("rdat.core: testing if xaxis is ready ...")
+      # req(!unselected(xaxis.), xaxis$in_sync())
+      req(!unselected(xaxis.))
       
       samples. <- rfds$active_samples()
       ftrace("Retrieving assay data for boxplot")
@@ -53,7 +58,7 @@ fboxPlotServer <- function(id, rfds, ...,
       agg. <- !indiv.
       batch. <- name(batch$batch)
       main. <- name(batch$main)
-
+      
       out <- rfds$fds() |> 
         fetch_assay_data(
           yvals., samples., normalized = TRUE,

--- a/R/fscatterPlot-modules.R
+++ b/R/fscatterPlot-modules.R
@@ -19,13 +19,7 @@ fscatterPlotServer <- function(id, rfds, ...,
     }, simplify = FALSE)
     
     features <- reactive({
-      lapply(dims, function(d) {
-        out <- d$selected()
-        # I've convinced myself that the `$in_sync()` calls has to come second,
-        # but I don't think that should be the case.
-        req(d$in_sync())
-        out
-      })
+      lapply(dims, function(d) d$selected())
     })
     ndim. <- reactive(sum(!sapply(features(), unselected)))
 

--- a/tests/shiny-modules/code-based-speed-tests.R
+++ b/tests/shiny-modules/code-based-speed-tests.R
@@ -27,7 +27,7 @@ system.time(test_sample_subset(samples.all, xfds))
 
 # 1a. retrieve all the sample covariate names.
 #    the first time, this takes ~7s, but subsequent calls are closer to 2.5s
-system.time(acovs <- fetch_sample_covariates(xfds, samples.all))
+system.time(acovs <- fetch_sample_covariates(samples.all))
 #  user  system elapsed 
 # 3.930   0.823   7.629 
 #  user  system elapsed 

--- a/tests/shiny-modules/datamods-example.R
+++ b/tests/shiny-modules/datamods-example.R
@@ -27,7 +27,7 @@ system.time(test_sample_subset(samples.all, xfds))
 
 # 1a. retrieve all the sample covariate names.
 #    the first time, this takes ~7s, but subsequent calls are closer to 2.5s
-system.time(acovs <- fetch_sample_covariates(xfds, samples.all))
+system.time(acovs <- fetch_sample_covariates(samples.all))
 #  user  system elapsed 
 # 3.930   0.823   7.629 
 #  user  system elapsed 

--- a/tests/shiny-modules/module-gallery.R
+++ b/tests/shiny-modules/module-gallery.R
@@ -1,9 +1,12 @@
 devtools::load_all(".")
 
 user <- Sys.getenv("USER")
+
 datadir <- "~/workspace/facilebio/data/"
-# datadir <- "~/workspace/projects/trv/chemoproteomics/faciledata"
+datadir <- "~/workspace/projects/trv/chemoproteomics/faciledata"
+datadir <- "~/workspace/projects/maze/maze-faciledatasets"
 debug <- TRUE
+
 options(facile.log.level.fshine = "trace")
 
 aes_color <- TRUE

--- a/tests/shiny-modules/shinytest-fboxPlot.R
+++ b/tests/shiny-modules/shinytest-fboxPlot.R
@@ -1,0 +1,22 @@
+devtools::load_all(".")
+# library(FacileShine)
+
+user <- Sys.getenv("USER")
+debug <- TRUE
+options(facile.log.level.fshine = "trace")
+
+# efds <- FacileData::exampleFacileDataSet()
+# gdb <- sparrow::exampleGeneSetDb()
+
+efds <- FacileData::FacileDataSet("~/workspace/projects/trv/chemoproteomics/faciledata/FacileKuljanin2021DataSet")
+shiny::shinyApp(
+  ui = shiny::fluidPage(
+    shinyjs::useShinyjs(),
+    filteredReactiveFacileDataStoreUI("rfds"),
+    shiny::tags$h3("facileBoxPlot"),
+    facileBoxPlotUI("box")),
+  server = function(input, output) {
+    rfds <- ReactiveFacileDataStore(efds, "rfds")
+    boxplot <- shiny::callModule(facileBoxPlot, "box", rfds, gdb = gdb)
+  }
+)


### PR DESCRIPTION
…ng `in_sync()` by themselves.

Code that uses assaySelect and assayFeatureSelect modules do not have to check if they are `module$in_sync()` before calling the `module$selected()` reactives. These reactives take care of the in_sync checks internally before returning their values.